### PR TITLE
feat: add PostHog integration

### DIFF
--- a/packages/web/.cursor/rules/posthog-integration.mdc
+++ b/packages/web/.cursor/rules/posthog-integration.mdc
@@ -1,0 +1,29 @@
+---
+description: apply when interacting with PostHog/analytics tasks
+globs: 
+alwaysApply: true
+---
+
+Never hallucinate an API key. Instead, always use the API key populated in the .env file.
+
+# Feature flags
+
+A given feature flag should be used in as few places as possible. Do not increase the risk of undefined behavior by scattering the same feature flag across multiple areas of code. If the same feature flag needs to be introduced at multiple callsites, flag this for the developer to inspect carefully.
+
+If a job requires creating new feature flag names, make them as clear and descriptive as possible.
+
+If using TypeScript, use an enum to store flag names. If using JavaScript, store flag names as strings to an object declared as a constant, to simulate an enum. Use a consistent naming convention for this storage. enum/const object members should be written UPPERCASE_WITH_UNDERSCORE.
+
+Gate flag-dependent code on a check that verifies the flag's values are valid and expected.
+
+# Custom properties
+
+If a custom property for a person or event is at any point referenced in two or more files or two or more callsites in the same file, use an enum or const object, as above in feature flags.
+
+# Naming
+
+Before creating any new event or property names, consult with the developer for any existing naming convention. Consistency in naming is essential, and additional context may exist outside this project. Similarly, be careful about any changes to existing event and property names, as this may break reporting and distort data for the project.
+
+
+
+

--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -41,3 +41,5 @@ next-env.d.ts
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+.env.local

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -17,10 +17,28 @@ const nextConfig = {
     };
     return config;
   },
-}
+  // PostHog rewrites
+  async rewrites() {
+    return [
+      {
+        source: '/ingest/static/:path*',
+        destination: 'https://us-assets.i.posthog.com/static/:path*',
+      },
+      {
+        source: '/ingest/:path*',
+        destination: 'https://us.i.posthog.com/:path*',
+      },
+      {
+        source: '/ingest/decide',
+        destination: 'https://us.i.posthog.com/decide',
+      },
+    ];
+  },
+  // This is required to support PostHog trailing slash API requests
+  skipTrailingSlashRedirect: true,
+};
 
-module.exports = nextConfig
-
+module.exports = nextConfig;
 
 // Injected content via Sentry wizard below
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -75,6 +75,8 @@
     "nuqs": "^2.4.1",
     "permissionless": "^0.2.42",
     "pg": "^8.14.1",
+    "posthog-js": "^1.242.2",
+    "posthog-node": "^4.17.1",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-hook-form": "catalog:",

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -7,7 +7,6 @@ import { Toaster } from "@/components/ui/sonner";
 
 const inter = Inter({ subsets: ['latin'] });
 
-
 export default function RootLayout({
   children,
 }: {

--- a/packages/web/src/components/PostHogProvider.tsx
+++ b/packages/web/src/components/PostHogProvider.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import posthog from "posthog-js"
+import { PostHogProvider as PHProvider, usePostHog } from "posthog-js/react"
+import { Suspense, useEffect } from "react"
+import { usePathname, useSearchParams } from "next/navigation"
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+      api_host: "/ingest",
+      ui_host: "https://us.posthog.com",
+      capture_pageview: false, // We capture pageviews manually
+      capture_pageleave: true, // Enable pageleave capture
+      debug: process.env.NODE_ENV === "development",
+    })
+  }, [])
+
+  return (
+    <PHProvider client={posthog}>
+      <SuspendedPostHogPageView />
+      {children}
+    </PHProvider>
+  )
+}
+
+function PostHogPageView() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const posthog = usePostHog()
+
+  useEffect(() => {
+    if (pathname && posthog) {
+      let url = window.origin + pathname
+      const search = searchParams.toString()
+      if (search) {
+        url += "?" + search
+      }
+      posthog.capture("$pageview", { "$current_url": url })
+    }
+  }, [pathname, searchParams, posthog])
+
+  return null
+}
+
+function SuspendedPostHogPageView() {
+  return (
+    <Suspense fallback={null}>
+      <PostHogPageView />
+    </Suspense>
+  )
+}

--- a/packages/web/src/components/providers.tsx
+++ b/packages/web/src/components/providers.tsx
@@ -8,13 +8,14 @@ import { ThemeProvider } from 'next-themes';
 import { WagmiProvider } from '@privy-io/wagmi';
 import { config as wagmiConfig } from '@/lib/wagmi';
 import { SmartWalletsProvider } from '@privy-io/react-auth/smart-wallets';
+import { PostHogProvider } from './PostHogProvider';
 
 const BASE_RPC_URL = process.env.NEXT_PUBLIC_BASE_RPC_URL as string;
 
 const BASE_FACTORY_ADDRESS = '0x1F8A80d853204B8E4e4C3b7a816eaf52eeEfAeee'; // Safe v1.4.1 proxy factory on Base mainnet
 const ENTRY_POINT_ADDRESS = '0x0576a174D229E3cFA37253523E645A78A0C91B57'; // EntryPoint v0.6 for Base
 
-// Smart‑wallet chain configuration for Privy
+// Smart-wallet chain configuration for Privy
 const smartWalletsConfig = {
   chains: [
     {
@@ -22,7 +23,7 @@ const smartWalletsConfig = {
       rpcUrl: BASE_RPC_URL,
       factoryAddress: BASE_FACTORY_ADDRESS,
       entryPointAddress: ENTRY_POINT_ADDRESS,
-      // Use an env‑specific bundler URL if provided, otherwise fall back to Privy's public bundler
+      // Use an env-specific bundler URL if provided, otherwise fall back to Privy's public bundler
       bundlerUrl: process.env.NEXT_PUBLIC_PRIVY_BUNDLER_URL ?? 'https://bundler.privy.io',
     },
   ],
@@ -68,37 +69,39 @@ export function Providers({ children }: { children: ReactNode }) {
   }
 
   return (
-    <PrivyProvider
-      appId={privyAppId}
-      config={{
-        appearance: {
-          theme: 'light',
-          accentColor: '#676FFF',
-          logo: 'https://pygvfunuirngbnf5.public.blob.vercel-storage.com/eqwrt-LXxp514DL8VsT9jGXUrVy6ItfqEhje.png',
-        },
-        externalWallets: {
-          coinbaseWallet: {
-            connectionOptions: 'smartWalletOnly',
+    <PostHogProvider>
+      <PrivyProvider
+        appId={privyAppId}
+        config={{
+          appearance: {
+            theme: 'light',
+            accentColor: '#676FFF',
+            logo: 'https://pygvfunuirngbnf5.public.blob.vercel-storage.com/eqwrt-LXxp514DL8VsT9jGXUrVy6ItfqEhje.png',
           },
-        },
-        supportedChains: [base],
-        defaultChain: base,
-        embeddedWallets: {
-          // Create an embedded EOA for *every* user, even if they logged in with Metamask.
-          // This gives us a deterministic signer for the downstream smart‑wallet client.
-          createOnLogin: 'all-users',
-        },
-      }}
-    >
-      <SmartWalletsProvider>
-        <QueryClientProvider client={queryClient}>
-          <WagmiProvider config={wagmiConfig}>
-            {/* <ThemeProvider attribute="class" defaultTheme="dark" enableSystem> */}
-            {children}
-            {/* </ThemeProvider> */}
-          </WagmiProvider>
-        </QueryClientProvider>
-      </SmartWalletsProvider>
-    </PrivyProvider>
+          externalWallets: {
+            coinbaseWallet: {
+              connectionOptions: 'smartWalletOnly',
+            },
+          },
+          supportedChains: [base],
+          defaultChain: base,
+          embeddedWallets: {
+            // Create an embedded EOA for *every* user, even if they logged in with Metamask.
+            // This gives us a deterministic signer for the downstream smart-wallet client.
+            createOnLogin: 'all-users',
+          },
+        }}
+      >
+        <SmartWalletsProvider config={smartWalletsConfig}>
+          <QueryClientProvider client={queryClient}>
+            <WagmiProvider config={wagmiConfig}>
+              {/* <ThemeProvider attribute="class" defaultTheme="dark" enableSystem> */}
+              {children}
+              {/* </ThemeProvider> */}
+            </WagmiProvider>
+          </QueryClientProvider>
+        </SmartWalletsProvider>
+      </PrivyProvider>
+    </PostHogProvider>
   );
 }

--- a/packages/web/src/lib/posthog.ts
+++ b/packages/web/src/lib/posthog.ts
@@ -1,0 +1,10 @@
+import { PostHog } from "posthog-node"
+
+export default function PostHogClient() {
+  const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    flushAt: 1,
+    flushInterval: 0,
+  })
+  return posthogClient
+}


### PR DESCRIPTION
This PR adds an integration for PostHog.

  The following changes were made:
  • Installed posthog-js & posthog-node packages
• Initialized PostHog and added pageview tracking
• Created a PostHogClient to use PostHog server-side
• Setup a reverse proxy to avoid ad blockers blocking analytics requests
  • Added Cursor rules for PostHog

  
  
  Note: This used the Next.js wizard to setup PostHog, this is still in alpha and like all AI, might have got it wrong. Please check the installation carefully!
  
  Learn more about PostHog + Next.js: https://posthog.com/docs/libraries/next-js